### PR TITLE
Do not remove gemini-report folder but just its content

### DIFF
--- a/src/index.es6
+++ b/src/index.es6
@@ -93,7 +93,7 @@ module.exports.test = function(options) {
     runPhantom();
 
     // Clean report
-    fs.removeSync(options.reportDir);
+    fs.removeSync(options.reportDir + '/*');
 
     // Run tests and create reports
     var runTests = function() {


### PR DESCRIPTION
When the test suite is started the report folder is removed.
It should be enough to remove all it's content instead of
removing the whole folder. This also prevents issues if there
are permissions missing to remove that folder.
