### PR TITLE
Do not break if gemini report could not be opened

### DIFF
--- a/src/index.es6
+++ b/src/index.es6
@@ -106,7 +106,7 @@ module.exports.test = function(options) {
       });
       runTestsPromise.done(result => {
         phantomProcess.kill('SIGTERM');
-        spawn('open', [`${options.reportDir}/index.html`])
+        spawn('open', [`${options.reportDir}/index.html`]).on('error', function() {});
       });
     };
     // TODO: remake with promises


### PR DESCRIPTION
Currently the test function throws an uncatched exception if the `open gemini-report/index.html` process could not be spawned after a test run.
An empty error handler has been added to catch that problem silently and do not break the whole process.

Fixes #11 
