### PR TITLE
Use modifier classname for test-name instead of the modifier counter

### DIFF
--- a/src/index.es6
+++ b/src/index.es6
@@ -152,13 +152,15 @@ module.exports.gather = function(options) {
           }
           examples.push(section.reference);
         } else {
-          for(var m = 1;m<=section.modifiers.length;m++) {
+          section.modifiers.forEach(function (modifier) {
+            var modifierFileIdentifier = section.reference + '-' + modifier.className.replace(' ', '_');
+
             // Exclude pages
-            if (options.excludePages.indexOf(`${section.reference}-${m}`) !== -1) {
-              continue;
+            if (options.excludePages.indexOf(modifierFileIdentifier) !== -1) {
+                return;
             }
-            examples.push(`${section.reference}-${m}`);
-          }
+            examples.push(modifierFileIdentifier);
+          });
         }
       });
       return examples;


### PR DESCRIPTION
If there are modifers the tests are named by the test name plus a counter
based on the modifier position. If you change the sorting or add a new
modifier you will get errors because the images have changed but they are
just stored under a new name. To fix that problem the modifier name is
used instead of the counter.
